### PR TITLE
fix: ready not emitting when no guilds

### DIFF
--- a/src/classes/websocket/handlers/READY.ts
+++ b/src/classes/websocket/handlers/READY.ts
@@ -32,7 +32,7 @@ export default async function READY (ws: Websocket, data: any): Promise<void> {
     ws.setStatus(Status.WAITING_FOR_GUILDS);
     ws.client.emit('waitingForGuilds');
 
-    if (!ws.expectedGuilds) {
+    if (!ws.expectedGuilds.size) {
         ws.client.debug('we didn\'t need to receive any guilds; marking as ready');
         ws.setStatus(Status.READY);
         ws.client.emit('ready');


### PR DESCRIPTION
The following test: [!ws.expectedGuilds](https://github.com/BirbJS/Birb/blob/main/src/classes/websocket/handlers/READY.ts#L35) will always return true no matter what.
Sets even if they're empty will always return true.
Sets extend Objects so these rules also apply to Arrays, Objects, Map, ...